### PR TITLE
Fix transipInstance.domainService.getDomainNames to also support a return value of only 1 domain

### DIFF
--- a/lib/domainService.js
+++ b/lib/domainService.js
@@ -122,9 +122,10 @@ domainService.prototype.getWhois = function getWhois(domain) {
  */
 domainService.prototype.getDomainNames = function getDomainNames() {
   return this.transip.communicate(this.service, 'getDomainNames').then(function(body) {
-    if(body[0]['return']['item'].length > 0) {
+    var items = [].concat(body[0]['return']['item']);
+    if(items.length > 0) {
       var domains = [];
-      return Promise.resolve(body[0]['return']['item']).each(function(domain) {
+      return Promise.resolve(items).each(function(domain) {
         domains.push(domain['$value']);
       }).then(function() {
         return domains;


### PR DESCRIPTION
getDomainNames currently returns an empty array when you have only 1 domain in your account. This PR fixes that.
